### PR TITLE
Implement Hex color codes

### DIFF
--- a/api/src/main/java/com/rappytv/globaltags/api/GlobalTagAPI.java
+++ b/api/src/main/java/com/rappytv/globaltags/api/GlobalTagAPI.java
@@ -4,12 +4,12 @@ import com.rappytv.globaltags.wrapper.GlobalTagsAPI;
 import com.rappytv.globaltags.wrapper.enums.AuthProvider;
 import net.labymod.api.Laby;
 import net.labymod.api.client.component.Component;
-import net.labymod.api.client.component.serializer.legacy.LegacyComponentSerializer;
 import net.labymod.api.labyconnect.LabyConnectSession;
 import net.labymod.api.labyconnect.TokenStorage.Purpose;
 import net.labymod.api.labyconnect.TokenStorage.Token;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -25,20 +25,21 @@ public class GlobalTagAPI extends GlobalTagsAPI<Component> {
 
     @Override
     public @NotNull Agent getAgent() {
-        return agent;
+        return this.agent;
     }
 
     @Override
     public @NotNull String getLanguageCode() {
-        return language.get();
+        return this.language.get();
     }
 
     @Override
     public @NotNull Component translateColorCodes(@Nullable String string) {
-        if(string == null) string = "";
-        return LegacyComponentSerializer
-            .legacyAmpersand()
-            .deserialize(string);
+        if (string == null || string.isEmpty()) {
+            return Component.empty();
+        }
+
+        return GlobalTagDeserializer.deserialize(string);
     }
 
     @Override

--- a/api/src/main/java/com/rappytv/globaltags/api/GlobalTagDeserializer.java
+++ b/api/src/main/java/com/rappytv/globaltags/api/GlobalTagDeserializer.java
@@ -1,0 +1,197 @@
+package com.rappytv.globaltags.api;
+
+import net.labymod.api.client.component.Component;
+import net.labymod.api.client.component.TextComponent;
+import net.labymod.api.client.component.format.NamedTextColor;
+import net.labymod.api.client.component.format.TextColor;
+import net.labymod.api.client.component.format.TextDecoration;
+import net.labymod.api.util.Color;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.include.com.google.common.collect.BiMap;
+import org.spongepowered.include.com.google.common.collect.HashBiMap;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Originally from net.labymod.api.client.component.serializer.legacy.LegacyComponentSerializer
+ */
+public class GlobalTagDeserializer {
+
+    private static final char RESET_CHAR = 'r';
+    private static final GlobalTagDeserializer INSTANCE = new GlobalTagDeserializer();
+
+    private static final BiMap<TextColor, Character> TEXT_COLOR_CHARS = HashBiMap.create(16);
+    private static final BiMap<TextDecoration, Character> DECORATION_CHARS = HashBiMap.create(5);
+
+    static {
+        TEXT_COLOR_CHARS.put(NamedTextColor.BLACK, '0');
+        TEXT_COLOR_CHARS.put(NamedTextColor.DARK_BLUE, '1');
+        TEXT_COLOR_CHARS.put(NamedTextColor.DARK_GREEN, '2');
+        TEXT_COLOR_CHARS.put(NamedTextColor.DARK_AQUA, '3');
+        TEXT_COLOR_CHARS.put(NamedTextColor.DARK_RED, '4');
+        TEXT_COLOR_CHARS.put(NamedTextColor.DARK_PURPLE, '5');
+        TEXT_COLOR_CHARS.put(NamedTextColor.GOLD, '6');
+        TEXT_COLOR_CHARS.put(NamedTextColor.GRAY, '7');
+        TEXT_COLOR_CHARS.put(NamedTextColor.DARK_GRAY, '8');
+        TEXT_COLOR_CHARS.put(NamedTextColor.BLUE, '9');
+        TEXT_COLOR_CHARS.put(NamedTextColor.GREEN, 'a');
+        TEXT_COLOR_CHARS.put(NamedTextColor.AQUA, 'b');
+        TEXT_COLOR_CHARS.put(NamedTextColor.RED, 'c');
+        TEXT_COLOR_CHARS.put(NamedTextColor.LIGHT_PURPLE, 'd');
+        TEXT_COLOR_CHARS.put(NamedTextColor.YELLOW, 'e');
+        TEXT_COLOR_CHARS.put(NamedTextColor.WHITE, 'f');
+
+        DECORATION_CHARS.put(TextDecoration.BOLD, 'l');
+        DECORATION_CHARS.put(TextDecoration.ITALIC, 'o');
+        DECORATION_CHARS.put(TextDecoration.UNDERLINED, 'n');
+        DECORATION_CHARS.put(TextDecoration.STRIKETHROUGH, 'm');
+        DECORATION_CHARS.put(TextDecoration.OBFUSCATED, 'k');
+    }
+
+    private final char character = '&';
+
+    private GlobalTagDeserializer() {
+        // Static access only
+    }
+
+    public static Component deserialize(String input) {
+        return INSTANCE.deserializeString(input);
+    }
+
+    public Component deserializeString(@Nullable String input) {
+        if (input == null) {
+            return Component.empty();
+        }
+
+        int nextSection = this.nextColor(input, input.length() - 1);
+        if (nextSection == -1) {
+            return Component.text(input);
+        }
+
+        boolean reset = false;
+        int pos = input.length();
+
+        TextComponent.Builder current = null;
+        List<Component> parts = new ArrayList<>();
+
+        do {
+            char format;
+            TextColor textColor = null;
+            TextDecoration decoration = null;
+            int from;
+
+            char formatIndicator = input.charAt(nextSection);
+            if (formatIndicator == this.character) {
+                format = input.charAt(nextSection + 1);
+                from = nextSection + 2;
+            } else if (formatIndicator == '#') {
+                format = formatIndicator;
+                int nextHexEnd = input.indexOf('>', nextSection);
+                if (nextHexEnd != -1) {
+                    String hex = input.substring(nextSection, nextHexEnd);
+                    int value;
+                    try {
+                        value = Integer.parseInt(hex.substring(1), 16);
+                    } catch (IllegalArgumentException ignored) {
+                        value = Color.WHITE.getValue();
+                    }
+
+                    textColor = TextColor.color(value);
+
+                    from = nextHexEnd + 1;
+                } else {
+                    from = nextSection;
+                }
+            } else {
+                format = RESET_CHAR;
+                from = nextSection;
+            }
+
+            if (format != RESET_CHAR && format != '#') {
+                textColor = TEXT_COLOR_CHARS.inverse().get(format);
+                if (textColor == null) {
+                    decoration = DECORATION_CHARS.inverse().get(format);
+                }
+            }
+
+            if (format == RESET_CHAR || textColor != null || decoration != null) {
+                if (from != pos) {
+                    if (current != null) {
+                        if (reset) {
+                            parts.add(current.build());
+                            reset = false;
+                            current = Component.text();
+                        } else {
+                            current = Component.text().append(current.build());
+                        }
+                    } else {
+                        current = Component.text();
+                    }
+
+                    current.text(input.substring(from, pos));
+                } else if (current == null) {
+                    current = Component.text();
+                }
+
+                if (!reset) {
+                    if (format == RESET_CHAR) {
+                        reset = true;
+                    } else if (textColor != null) {
+                        current.color(textColor);
+                        reset = true;
+                    } else {
+                        current.decorate(decoration);
+                    }
+                }
+
+                pos = formatIndicator == '#' ? nextSection - 1 : nextSection;
+            }
+
+            nextSection = this.nextColor(input, nextSection - 1);
+        } while (nextSection != -1);
+
+        if (current != null) {
+            parts.add(current.build());
+        }
+
+        final String remaining = pos > 0 ? input.substring(0, pos) : "";
+        if (parts.size() == 1 && remaining.isEmpty()) {
+            return parts.getFirst();
+        } else {
+            Collections.reverse(parts);
+            return Component.text().text(remaining).append(parts).build();
+        }
+    }
+
+    private int nextColor(String input, int fromIndex) {
+        if (fromIndex < 0) {
+            return -1;
+        }
+
+        int nextSection = input.lastIndexOf(this.character, fromIndex);
+        if (nextSection > input.length() - 2) {
+            // there cannot be a legacy color code at the end of the string
+            nextSection = -1;
+        }
+
+        int nextHexEnd = input.lastIndexOf('>', fromIndex);
+        if (nextHexEnd == -1) {
+            // no hex color, so use the next section
+            return nextSection;
+        }
+
+        int nextHexStart = input.lastIndexOf("<#", nextHexEnd);
+        if (nextHexStart == -1) {
+            // no hex color, so use the next section
+            return nextSection;
+        }
+
+        if (nextHexStart > nextSection) {
+            return nextHexStart + 1;
+        }
+
+        return nextSection;
+    }
+}

--- a/core/src/main/java/com/rappytv/globaltags/config/widget/TagPreviewWidget.java
+++ b/core/src/main/java/com/rappytv/globaltags/config/widget/TagPreviewWidget.java
@@ -14,6 +14,7 @@ import net.labymod.api.client.gui.icon.Icon;
 import net.labymod.api.client.gui.lss.property.annotation.AutoWidget;
 import net.labymod.api.client.gui.screen.Parent;
 import net.labymod.api.client.gui.screen.activity.Link;
+import net.labymod.api.client.gui.screen.widget.Widget;
 import net.labymod.api.client.gui.screen.widget.widgets.ComponentWidget;
 import net.labymod.api.client.gui.screen.widget.widgets.input.ButtonWidget;
 import net.labymod.api.client.gui.screen.widget.widgets.layout.list.HorizontalListWidget;
@@ -25,10 +26,13 @@ import net.labymod.api.configuration.settings.annotation.SettingFactory;
 import net.labymod.api.configuration.settings.annotation.SettingWidget;
 import net.labymod.api.configuration.settings.widget.WidgetFactory;
 import net.labymod.api.util.I18n;
+import net.labymod.api.util.ThreadSafe;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.function.Consumer;
 
 @Link("preview.lss")
 @AutoWidget
@@ -49,7 +53,7 @@ public class TagPreviewWidget extends HorizontalListWidget {
         if(!refetch && !changed) return;
         if(refetch)
             GlobalTagAddon.getAPI().getCache().remove(GlobalTagAddon.getAPI().getClientUUID());
-        reInitialize();
+        this.reInitialize();
         refetch = false;
         changed = false;
     }
@@ -57,76 +61,92 @@ public class TagPreviewWidget extends HorizontalListWidget {
     @Override
     public void initialize(Parent parent) {
         super.initialize(parent);
-        initialize(refetch);
+        this.initialize(refetch);
     }
 
     @SuppressWarnings("ConstantConditions")
     public void initialize(boolean refetched) {
         GlobalTagAPI api = GlobalTagAddon.getAPI();
-        api.getCache().resolveSelf((info) ->
-            Laby.labyAPI().minecraft().executeOnRenderThread(() -> {
-                Component error = getError(info);
-                if (error != null) {
-                    ComponentWidget errorComponent = ComponentWidget.component(error)
-                        .addId("text", "error");
-                    this.addEntryInitialized(errorComponent);
-                } else {
-                    if(refetched) {
-                        config.tag().set(info.getPlainTag());
-                        config.position().set(info.getPosition());
-                        config.icon().set(info.getGlobalIcon());
-                    }
-                    boolean updated = !config.tag().get().equals(info.getPlainTag())
-                        || !config.position().get().equals(info.getPosition())
-                        || !config.icon().get().equals(info.getGlobalIcon());
-                    if(changed && updated) {
-                        Util.notify(
-                            I18n.translate("globaltags.settings.tags.staged.title"),
-                            I18n.translate("globaltags.settings.tags.staged.description")
-                        );
-                    }
-                    ComponentWidget tag = ComponentWidget.component(
-                        config.tag().get().isBlank()
-                            ? Component.translatable(
-                                "globaltags.settings.tags.tagPreview.empty",
-                                NamedTextColor.RED
-                            )
-                            : api.translateColorCodes(config.tag().get())
-                    ).addId("text");
-
-                    if (config.icon().get() != GlobalIcon.NONE) {
-                        String iconUrl = config.icon().get() == GlobalIcon.CUSTOM && info.getGlobalIconHash() != null
-                            ? api.getUrls().getCustomIcon(api.getClientUUID(), info.getGlobalIconHash())
-                            : api.getUrls().getDefaultIcon(config.icon().get());
-                        this.addEntryInitialized(
-                            new IconWidget(Icon.url(iconUrl))
-                                .addId("icon")
-                        );
-                    }
-                    this.addEntryInitialized(tag);
-                    if (info.getHighestRoleIcon() != null)
-                        this.addEntryInitialized(
-                            new IconWidget(Icon.url(info.getHighestRoleIcon()))
-                                .addId("staff-icon")
-                        );
-                }
-                ButtonWidget refreshButton = ButtonWidget.icon(SpriteCommon.REFRESH, TagPreviewWidget::refetch)
-                    .addId("refresh-button");
-                addEntryInitialized(refreshButton);
-                if(info != null && info.isSuspended()) {
-                    ButtonWidget appealButton = ButtonWidget.i18n(
-                        "globaltags.settings.tags.tagPreview.appeal.name",
-                        () -> new AppealPopup(api).displayInOverlay()
-                    ).addId("appeal-button");
-                    appealButton.setHoverComponent(Component.translatable(
-                        "globaltags.settings.tags.tagPreview.appeal.description",
-                        NamedTextColor.GOLD
-                    ));
-                    appealButton.setEnabled(info.getSuspension().isAppealable());
-                    addEntryInitialized(appealButton);
-                }
-            }));
+        api.getCache().resolveSelf((info) -> {
+            if (ThreadSafe.isRenderThread()) {
+                this.initializeWithInfo(info, refetched, false);
+            } else {
+                Laby.labyAPI().minecraft().executeOnRenderThread(
+                    () -> this.initializeWithInfo(info, refetched, true)
+                );
+            }
+        });
     }
+
+    private void initializeWithInfo(PlayerInfo<Component> info, boolean refetched, boolean async) {
+        GlobalTagAPI api = GlobalTagAddon.getAPI();
+        Consumer<Widget> addEntry = async ? this::addEntryInitialized : this::addEntry;
+
+        Component error = this.getError(info);
+        if (error != null) {
+            ComponentWidget errorComponent = ComponentWidget.component(error)
+                .addId("text", "error");
+            addEntry.accept(errorComponent);
+        } else {
+            if (refetched) {
+                this.config.tag().set(info.getPlainTag());
+                this.config.position().set(info.getPosition());
+                this.config.icon().set(info.getGlobalIcon());
+            }
+            boolean updated = !this.config.tag().get().equals(info.getPlainTag())
+                || !this.config.position().get().equals(info.getPosition())
+                || !this.config.icon().get().equals(info.getGlobalIcon());
+            if (changed && updated) {
+                Util.notify(
+                    I18n.translate("globaltags.settings.tags.staged.title"),
+                    I18n.translate("globaltags.settings.tags.staged.description")
+                );
+            }
+            ComponentWidget tag = ComponentWidget.component(
+                this.config.tag().get().isBlank()
+                    ? Component.translatable(
+                    "globaltags.settings.tags.tagPreview.empty",
+                    NamedTextColor.RED
+                )
+                    : api.translateColorCodes(this.config.tag().get())
+            ).addId("text");
+
+            if (this.config.icon().get() != GlobalIcon.NONE) {
+                String iconUrl =
+                    this.config.icon().get() == GlobalIcon.CUSTOM && info.getGlobalIconHash() != null
+                        ? api.getUrls().getCustomIcon(api.getClientUUID(), info.getGlobalIconHash())
+                        : api.getUrls().getDefaultIcon(this.config.icon().get());
+                addEntry.accept(
+                    new IconWidget(Icon.url(iconUrl))
+                        .addId("icon")
+                );
+            }
+            addEntry.accept(tag);
+            if (info.getHighestRoleIcon() != null) {
+                addEntry.accept(
+                    new IconWidget(Icon.url(info.getHighestRoleIcon()))
+                        .addId("staff-icon")
+                );
+            }
+        }
+        ButtonWidget refreshButton = ButtonWidget.icon(SpriteCommon.REFRESH,
+                TagPreviewWidget::refetch)
+            .addId("refresh-button");
+        addEntry.accept(refreshButton);
+        if (info != null && info.isSuspended()) {
+            ButtonWidget appealButton = ButtonWidget.i18n(
+                "globaltags.settings.tags.tagPreview.appeal.name",
+                () -> new AppealPopup(api).displayInOverlay()
+            ).addId("appeal-button");
+            appealButton.setHoverComponent(Component.translatable(
+                "globaltags.settings.tags.tagPreview.appeal.description",
+                NamedTextColor.GOLD
+            ));
+            appealButton.setEnabled(info.getSuspension().isAppealable());
+            addEntry.accept(appealButton);
+        }
+    }
+
 
     public static void change() {
         TagPreviewWidget.changed = true;


### PR DESCRIPTION
This pull request implements hex color codes, as can be seen in the following screenshot:

![image](https://github.com/user-attachments/assets/3b19f822-ad2a-4fea-aff1-98e53bc7adb5)

The "syntax" for the shown global tag is:
`<#5a5178>R<#785174>eg<#9e5480>en<#9e545d>bo<#ad7d50>ge<#99ad50>n <#5fb045>oder so`


Additionally, the duplicate refresh icon in the settings is now fixed by checking if the button should be added normally or if it should be initialized directly after adding.